### PR TITLE
Update Mesh otel demo with new MeshMetric policy

### DIFF
--- a/mesh-otel/install-obs.sh
+++ b/mesh-otel/install-obs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+kubectl create namespace observability
 
 kubectl delete secret -n observability otel-providers
 kubectl create secret generic -n observability otel-providers \
@@ -10,5 +11,3 @@ kubectl create secret generic -n observability otel-providers \
 kubectl apply -f otel-collectors.yaml
 
 kubectl rollout restart -n observability deployment/otel-collector
-
-

--- a/mesh-otel/otel-collectors.yaml
+++ b/mesh-otel/otel-collectors.yaml
@@ -142,29 +142,6 @@ data:
               source_labels:
               - __meta_kubernetes_pod_node_name
               target_label: kubernetes_node
-          - job_name: 'kuma-dataplanes'
-            scrape_interval: '10s'
-            relabel_configs:
-              - source_labels:
-                  - __meta_kuma_mesh
-                regex: "(.*)"
-                target_label: mesh
-              - source_labels:
-                  - __meta_kuma_dataplane
-                regex: "(.*)"
-                target_label: dataplane
-              - source_labels:
-                  - __meta_kuma_service
-                regex: "(.*)"
-                target_label: service
-              - action: labelmap
-                regex: __meta_kuma_label_(.+)
-              - action: labelmap
-                regex: __(address)__
-              - action: labelmap
-                regex: __(meta_kubernetes.*)__
-            kuma_sd_configs:
-              - server: "http://kong-mesh-control-plane.kong-mesh-system.svc:5676" # replace with the url of your control plane
     processors:
       batch:
         send_batch_size: 4096
@@ -210,7 +187,7 @@ data:
           processors: [memory_limiter, batch]
           exporters: [otlphttp/grafana, otlp/honeycomb, datadog]
         metrics:
-          receivers: [prometheus]
+          receivers: [prometheus, otlp]
           processors: [batch]
           exporters: [otlphttp/grafana, otlp/honeycomb, datadog]
         logs:
@@ -267,7 +244,7 @@ spec:
       containers:
         - args:
             - "--config=/conf/otel-collector-config.yaml"
-          image: otel/opentelemetry-collector-contrib:0.83.0
+          image: otel/opentelemetry-collector-contrib:0.96.0
           name: otel-collector
           resources:
             limits:

--- a/mesh-otel/telemetry.yaml
+++ b/mesh-otel/telemetry.yaml
@@ -5,15 +5,18 @@ mtls:
   backends:
     - name: ca-1
       type: builtin
-metrics:
-  enabledBackend: prometheus-1
-  backends:
-    - name: prometheus-1
-      type: prometheus
-      conf:
-        skipMTLS: true
-        envoy:
-          usedOnly: true
+---
+type: MeshMetric
+name: otel
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          endpoint: otel-collector.observability.svc:4317
 ---
 type: MeshTrace
 name: otel


### PR DESCRIPTION
In Kuma and Kong Mesh 2.6.0 we've added new MeshMetric policy that supports pushing metrics to OTEL collector